### PR TITLE
Video streaming setup fixed

### DIFF
--- a/SDLStreamingVideoExample/VideoManager.m
+++ b/SDLStreamingVideoExample/VideoManager.m
@@ -150,7 +150,12 @@ static NSString *kRateKey = @"rate";
  */
 - (void)startVideo {
     [self.player play];
-    if (self.videoStreamingStartedHandler == nil) { return; }
+    if (self.videoStreamingStartedHandler == nil) {
+        SDLLogE(@"Video started playing...but no delegates to notify, returning");
+        return;
+    }
+
+    SDLLogD(@"Video started playing...notifying delegates");
     self.videoStreamingStartedHandler();
 }
 


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
None written.

### Summary
- Video setup is done in Proxy Manager init now instead of waiting until the HMI state changes to non-none. This fixes an issue where the video player never got setup because the HMI state notification was sent after video streaming setup was completed in the streaming media manager. 
